### PR TITLE
Add ProductId for StorePurchaseApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Add Windows Store for LTSC2021/2024
 
 Note:  
-Microsoft.StorePurchaseApp: CategoryID=214308d7-4262-449d-a78d-9a2306144b11  
+Microsoft.StorePurchaseApp: ProductId=9NBLGGH4LS1F, CategoryID=214308d7-4262-449d-a78d-9a2306144b11  
 Microsoft.WindowsStore: ProductId=9WZDNCRFJBMP  
 Microsoft.DesktopAppInstaller: ProductId=9NBLGGH4NNS1  
 Microsoft.XboxIdentityProvider: ProductId=9WZDNCRD1HKW  


### PR DESCRIPTION
Having the productid for the "StorePurchaseApp" component will allow people to install+update with winget.

I pulled this productid from the registry of a non-ltsc windows install