### PR TITLE
UPDATED: Add missing PackageID and winget instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Add Windows Store for LTSC2021/2024
 
 Note:  
-Microsoft.StorePurchaseApp: CategoryID=214308d7-4262-449d-a78d-9a2306144b11  
+Microsoft.StorePurchaseApp: ProductId=9NBLGGH4LS1F, CategoryID=214308d7-4262-449d-a78d-9a2306144b11  
 Microsoft.WindowsStore: ProductId=9WZDNCRFJBMP  
 Microsoft.DesktopAppInstaller: ProductId=9NBLGGH4NNS1  
 Microsoft.XboxIdentityProvider: ProductId=9WZDNCRD1HKW  

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Microsoft.XboxIdentityProvider: ProductId=9WZDNCRD1HKW
 
 To install with winget:
 ```
-winget install --id 9NBLGGH4LS1F
-winget install --id 9WZDNCRFJBMP
-winget install --id 9NBLGGH4NNS1
-winget install --id 9WZDNCRD1HKW
+winget install --id 9NBLGGH4LS1F -s msstore
+winget install --id 9WZDNCRFJBMP -s msstore
+winget install --id 9NBLGGH4NNS1 -s msstore
+winget install --id 9WZDNCRD1HKW -s msstore
 ```

--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ Microsoft.WindowsStore: ProductId=9WZDNCRFJBMP
 Microsoft.DesktopAppInstaller: ProductId=9NBLGGH4NNS1  
 Microsoft.XboxIdentityProvider: ProductId=9WZDNCRD1HKW  
 [Online link generator for Microsoft Store](https://store.rg-adguard.net/)
+
+To install with winget:
+```
+winget install --id 9NBLGGH4LS1F
+winget install --id 9WZDNCRFJBMP
+winget install --id 9NBLGGH4NNS1
+winget install --id 9WZDNCRD1HKW
+```


### PR DESCRIPTION
I have added the missing PackageID for StorePurchaseApp.

Additionally, I think it would be helpful to have the winget commands listed as many people on LTSC use winget to install and manage package updates.